### PR TITLE
Integrate gutenberg-mobile release 1.53.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.53.0'
+    ext.gutenbergMobileVersion = '4-9330296ba9b039d1701fa7a45f49ab8e102c6198'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.53.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/AmandaRiu/gutenberg-mobile/pull/4

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.